### PR TITLE
load css from gresource, improve the constants file

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -1,0 +1,22 @@
+.temp {
+    font-size: 250%;
+    font-weight: 500;
+}
+.weather {
+    font-size: 170%;
+}
+.resumen {
+    font-size: 110%;
+}
+.preferences {
+    font-size: 110%;
+    font-weight: 600;
+}
+.ticket {
+    background-color: @text-color;
+    color: @background_color;
+    opacity: 0.5;
+}
+.ticket:hover {
+    opacity: 1.0;
+}

--- a/data/com.github.bitseater.weather.desktop.in
+++ b/data/com.github.bitseater.weather.desktop.in
@@ -1,16 +1,7 @@
 [Desktop Entry]
 Name=Weather
-Name[es]=Tiempo
-Name[fr]=Météo
-Name[lt]=Orai
 GenericName=Weather
-GenericName[es]=Tiempo
-GenericName[fr]=Météo
-GenericName[lt]=Orai
 Comment=Forecast App for desktop
-Comment[es]=Previsión meteorológica para el escritorio
-Comment[fr]=Prévisions météorologiques pour le bureau
-Comment[lt]=Orų prognozės programa, skirta darbalaukiui
 Categories=Utility;Education;Science;
 Exec=com.github.bitseater.weather
 Icon=com.github.bitseater.weather
@@ -18,7 +9,4 @@ Terminal=false
 Type=Application
 X-GNOME-Gettext-Domain=com.github.bitseater.weather
 Keywords=Weather;Forecast;Temperature;
-Keywords[es]=Meteorología;Temperatura;Previsión;Lluvia;Clima;Meteorológico;
-Keywords[fr]=Météo;Prévisions;Température;Météorologie;Météorologique;Celcius;Degré;
-Keywords[lt]=Orai;Prognozė;Temperatūra;Oras;
 X-GNOME-UsesNotifications=true

--- a/data/com.github.bitseater.weather.gresource.xml
+++ b/data/com.github.bitseater.weather.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/bitseater/weather">
+    <file>application.css</file>
+  </gresource>
+</gresources>

--- a/data/meson.build
+++ b/data/meson.build
@@ -21,6 +21,12 @@ install_data(
     install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
 )
 
+asresources = gnome.compile_resources(
+  'as-resources', meson.project_name() + '.gresource.xml',
+  source_dir: '.',
+  c_name: 'as'
+)
+
 
 i18n.merge_file(
   input: meson.project_name() + '.desktop.in',

--- a/meson.build
+++ b/meson.build
@@ -5,53 +5,68 @@ project('com.github.bitseater.weather', ['vala', 'c'], version: '0.5.3')
 gnome = import('gnome')
 i18n = import('i18n')
 
-## Compile GResources
-## asresources = gnome.compile_resources(
-##    'as-resources', 'data/weather.gresource.xml',
-##    source_dir: 'data',
-##    c_name: 'as'
-##)
-
 # Add vapi files
-#add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')], language: 'vala')
+add_project_arguments(
+  [
+    '--vapidir',
+    join_paths(meson.current_source_dir(), 'vapi')
+  ],
+  language: 'vala'
+)
 
 # Add locale support
 conf = configuration_data()
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
-configure_file(output: 'config.h', configuration: conf)
-config_h_dir = include_directories('.')
+conf.set_quoted('PREFIX', get_option('prefix'))
+conf.set_quoted('VERSION', meson.project_version())
+conf.set_quoted('PACKAGE', meson.project_name())
+conf.set_quoted('LOCALE_DIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))
+conf.set_quoted('PKG_DATADIR', join_paths(get_option('prefix'), get_option('datadir'), meson.project_name()))
+
+configure_file(
+  output: 'config.h',
+  configuration: conf
+)
+config_h_dir = include_directories('src')
 
 # Arguments C - no gcc warnings
 c_args = [
-  '-w', '-DGETTEXT_PACKAGE="' + meson.project_name() + '"']
+  '-include', 'config.h',
+  '-w', '-DGETTEXT_PACKAGE="' + meson.project_name() + '"'
+]
 
 cc = meson.get_compiler('c')
+
+# Add subfolders
+subdir('data')
+subdir('po')
 
 # Define executable
 executable(
     meson.project_name(),
-        'src/Constants.vala',
-        'src/MainWindow.vala',
-        'src/Utils/GeoLocate.vala',
-        'src/Utils/Iconame.vala',
-        'src/Utils/MapCity.vala',
-        'src/Utils/MapLayer.vala',
-        'src/Utils/MiniMap.vala',
-        'src/Utils/OWM_Today.vala',
-        'src/Utils/Utils.vala',
-        'src/Weather.vala',
-        'src/Widgets/About.vala',
-        'src/Widgets/Apikey.vala',
-        'src/Widgets/City.vala',
-        'src/Widgets/Current.vala',
-        'src/Widgets/Forecast.vala',
-        'src/Widgets/Header.vala',
-        'src/Widgets/MapView.vala',
-        'src/Widgets/MapViewOWM.vala',
-        'src/Widgets/Preferences.vala',
-        'src/Widgets/Ticket.vala',
-        'src/Widgets/Today.vala',
-##    asresources,
+    'src/Constants.vala',
+    'src/MainWindow.vala',
+    'src/Utils/GeoLocate.vala',
+    'src/Utils/Iconame.vala',
+    'src/Utils/MapCity.vala',
+    'src/Utils/MapLayer.vala',
+    'src/Utils/MiniMap.vala',
+    'src/Utils/OWM_Today.vala',
+    'src/Utils/Utils.vala',
+    'src/Weather.vala',
+    'src/Widgets/About.vala',
+    'src/Widgets/Apikey.vala',
+    'src/Widgets/City.vala',
+    'src/Widgets/Current.vala',
+    'src/Widgets/Forecast.vala',
+    'src/Widgets/Header.vala',
+    'src/Widgets/MapView.vala',
+    'src/Widgets/MapViewOWM.vala',
+    'src/Widgets/Preferences.vala',
+    'src/Widgets/Ticket.vala',
+    'src/Widgets/Today.vala',
+    asresources,
     c_args: c_args,
     dependencies: [
         dependency('gio-2.0'),
@@ -67,17 +82,13 @@ executable(
         dependency('webkit2gtk-4.0'),
         dependency('appindicator3-0.1'),
     ],
+
+    vala_args: [
+        meson.source_root() + '/vapi/config.vapi'
+    ],
     link_args: ['-lm'],
-##    vala_args: [
-##        '--gresources=' + meson.source_root() + '/data/weather.gresource.xml',
-##    ],
     install : true
 )
-
-# Add subfolders
-subdir('data')
-subdir('po')
-
 
 # Add post install script
 meson.add_install_script('meson/post_install.py')

--- a/src/Constants.vala
+++ b/src/Constants.vala
@@ -19,15 +19,16 @@
 * Authored by: Carlos Suárez <bitseater@gmail.com>
 */
 namespace Constants {
-    public const string DATADIR = "/usr/share";
-    public const string PKGDATADIR = "/usr/share/com.github.bitseater.weather";
-    public const string GETTEXT_PACKAGE = "weather";
+    public const string DATADIR = Config.DATADIR;
+    public const string PKGDATADIR = Config.PKG_DATADIR;
+    public const string GETTEXT_PACKAGE = Config.GETTEXT_PACKAGE;
     public const string RELEASE_NAME = "Loki";
-    public const string VERSION = "0.5.3";
+    public const string VERSION = Config.VERSION;
     public const string VERSION_INFO = "Release";
-    public const string INSTALL_PREFIX = "/usr";
+    public const string INSTALL_PREFIX = Config.PREFIX;
     public const string APP_NAME = "Weather";
-    public const string EXEC_NAME = "com.github.bitseater.weather";
-    public const string ICON_NAME = "com.github.bitseater.weather";
+    public const string EXEC_NAME = Config.PACKAGE;
+    public const string ICON_NAME = Config.PACKAGE;
     public const string OWM_API_ADDR = "http://api.openweathermap.org/data/2.5/";
+    public const string LOCALE_DIR = Config.LOCALE_DIR;
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -35,33 +35,9 @@ namespace Weather {
             this.set_titlebar (header);
 
             //Define style
-            string weather_css = """
-                .temp {
-                    font-size: 250%;
-                    font-weight: 500;
-                }
-                .weather {
-                    font-size: 170%;
-                }
-                .resumen {
-                    font-size: 110%;
-                }
-                .preferences {
-                    font-size: 110%;
-                    font-weight: 600;
-                }
-                .ticket {
-                    background-color: @text-color;
-                    color: @background_color;
-                    opacity: 0.5;
-                }
-                .ticket:hover {
-                    opacity: 1.0;
-                }
-            """;
             var provider = new Gtk.CssProvider();
             try {
-                provider.load_from_data (weather_css, -1);
+                provider.load_from_resource ("/com/github/bitseater/weather/application.css");
             } catch (GLib.Error e) {
                 GLib.error ("Failed to load css: %s", e.message);
             }

--- a/src/Weather.vala
+++ b/src/Weather.vala
@@ -32,7 +32,7 @@ namespace Weather {
             string package_name = Constants.GETTEXT_PACKAGE;
             Intl.setlocale (LocaleCategory.ALL, "");
             Intl.textdomain (package_name);
-            Intl.bindtextdomain (package_name, "./locale");
+            Intl.bindtextdomain (package_name, Constants.LOCALE_DIR);
             Intl.bind_textdomain_codeset (package_name, "UTF-8");
         }
 

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -1,0 +1,10 @@
+[CCode (cprefix = "", lower_case_cprefix = "", cheader_filename = "config.h")]
+namespace Config {
+	public const string DATADIR;
+	public const string PKG_DATADIR;
+	public const string GETTEXT_PACKAGE;
+	public const string LOCALE_DIR;
+	public const string VERSION;
+	public const string PREFIX;
+	public const string PACKAGE;
+}


### PR DESCRIPTION
The constants file used to have some hardcoded values that depends on the build flags. Like the prefix...
The same for the gettext init, the locale directory depends on the --localedir flag.

This PR fixes that, and also moves the css from the vala file to a gresource file


